### PR TITLE
Myprofile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -51,7 +51,10 @@ class ProfilesController < ApplicationController
 
       # when the user have not updated profile redirect to update
       def force_update_current_user_profile
-        if !current_user.profile.name
+        # To be sure if user profile has some details
+        # need to check both if user profile exists and if profile has a name 
+        # since profile is created first time the app renders edit form
+        if !current_user.profile || !current_user.profile.name
           redirect_to edit_myprofile_path, alert: 'Please first update your profile!'
         end  
       end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
 
+  # below validations are forced only on profile update
   validates :name, presence: true, on: :update
   validates :location, presence: true, on: :update
   # regular expression to check valid australian phone numbers


### PR DESCRIPTION
Fixed a bug in the profiles controller and added a comment on profiles model validations

In force_update_current_user_profile method, while checking for if the user profile is updated the method was erroring since it was using the condition "if !current_user.profile.name" that was erroring when the user visits my profile page and the profile did not exist so it gave the error 

020-03-04T02:37:22.762737+00:00 app[web.1]: F, [2020-03-04T02:37:22.762666 #4] FATAL -- : [e330f3b3-2f29-43bd-b288-28d911d825c9] NoMethodError (undefined method `name' for nil:NilClass):
2020-03-04T02:37:22.762899+00:00 app[web.1]: F, [2020-03-04T02:37:22.762801 #4] FATAL -- : [e330f3b3-2f29-43bd-b288-28d911d825c9]   
2020-03-04T02:37:22.762976+00:00 app[web.1]: F, [2020-03-04T02:37:22.762907 #4] FATAL -- : [e330f3b3-2f29-43bd-b288-28d911d825c9] app/controllers/profiles_controller.rb:54:in `force_update_current_user_profile'

fixed the bug by improving the condition

if !current_user.profile || !current_user.profile.name